### PR TITLE
the bullseye check is using the "main" branch

### DIFF
--- a/.github/workflows/ansible-debian-bullseye.yml
+++ b/.github/workflows/ansible-debian-bullseye.yml
@@ -11,8 +11,7 @@ jobs:
         uses: actions/checkout@v2
 
       - name: ansible check with debian:bullseye (11)
-        uses: roles-ansible/check-ansible-debian-bullseye-action@master
-        with:
+        uses: roles-ansible/check-ansible-debian-bullseye-action@main
           group: local
           hosts: localhost
           targets: "tests/*.yml"


### PR DESCRIPTION
The https://github.com/marketplace/actions/check-ansible-debian-bullseye is available at the "main" branch.